### PR TITLE
Fix filter_executions order

### DIFF
--- a/lib/xcprofiler/reporters/abstract_reporter.rb
+++ b/lib/xcprofiler/reporters/abstract_reporter.rb
@@ -13,8 +13,8 @@ module Xcprofiler
     def filter_executions(executions)
       executions = sort_executions(executions, order)
       executions = executions.delete_if(&:invalid?) unless show_invalid_locations?
-      executions = executions[0...limit] if limit
       executions = executions.delete_if { |v| v.time < threshold } if threshold
+      executions = executions[0...limit] if limit
       executions
     end
 

--- a/lib/xcprofiler/reporters/abstract_reporter.rb
+++ b/lib/xcprofiler/reporters/abstract_reporter.rb
@@ -27,7 +27,7 @@ module Xcprofiler
         when :time
           executions.sort { |a, b| [b.time, (a.filename or ''), (a.line or 0)] <=> [a.time, (b.filename or ''), (b.line or 0)] }
         when :file
-          executions.sort { |a, b| [(a.filename or ''), (a.line or 0)] <=> [(b.filename or ''), (b.line or 0)] }
+          executions.sort { |a, b| [(a.filename or ''), (a.line or 0), b.time] <=> [(b.filename or ''), (b.line or 0), a.time] }
       end
     end
 

--- a/spec/reporters/abstract_reporter_spec.rb
+++ b/spec/reporters/abstract_reporter_spec.rb
@@ -161,7 +161,6 @@ describe AbstractReporter do
         end
       end
 
-
       context 'with threshold and show_invalid_locations' do
         let(:reporter) { AbstractReporter.new({threshold: threshold, show_invalid_locations: show_invalid_locations}) }
 

--- a/spec/reporters/abstract_reporter_spec.rb
+++ b/spec/reporters/abstract_reporter_spec.rb
@@ -110,5 +110,111 @@ describe AbstractReporter do
         expect(filtered_executions.first).to eql(invalid_executions.last)
       end
     end
+
+    context 'with multi_options' do
+      let(:order) { :file }
+      let(:limit) { 5 }
+      let(:threshold) { 1 }
+      let(:show_invalid_locations) { true }
+      context 'with order and limit' do
+        let(:reporter) { AbstractReporter.new({order: order, limit: limit}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(valid_executions.first)
+        end
+      end
+
+      context 'with order and threshold' do
+        let(:reporter) { AbstractReporter.new({order: order, threshold: threshold}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(9)
+          expect(filtered_executions.first).to eql(valid_executions[1])
+        end
+      end
+
+      context 'with order and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({order: order, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(20)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+      context 'with limit and threshold' do
+        let(:reporter) { AbstractReporter.new({limit: limit, threshold: threshold}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(valid_executions.last)
+        end
+      end
+
+      context 'with limit and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({limit: limit, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+
+      context 'with threshold and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({threshold: threshold, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(18)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+      context 'with order, limit and threshold' do
+        let(:reporter) { AbstractReporter.new({order: order, limit: limit, threshold: threshold}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(valid_executions[1])
+        end
+      end
+
+      context 'with order, limit and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({order: order, limit: limit, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+      context 'with order, threshold and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({order: order, threshold: threshold, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(18)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+      context 'with limit, threshold and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({limit: limit, threshold: threshold, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+
+      context 'with order, limit, threshold and show_invalid_locations' do
+        let(:reporter) { AbstractReporter.new({order: order, limit: limit, threshold: threshold, show_invalid_locations: show_invalid_locations}) }
+
+        it 'returns filtered executions' do
+          expect(filtered_executions.size).to eql(limit)
+          expect(filtered_executions.first).to eql(invalid_executions.last)
+        end
+      end
+    end 
   end
 end


### PR DESCRIPTION
Fixed bug related to #2. 

### Before the change:

```
$ xcprofiler MyApp -l 10 --threshold 300 -o file
```
1. Sort data
2. Extract limited count
3. Delete data below threshold

=> Extract incorrect count due to 3.

### After the change:
```
$ xcprofiler MyApp -l 10 --threshold 300 -o file
```

1. Sort data
2. Delete data below threshold
3. Extract limited count

=> Extract limited count.