### PR TITLE
Implemented the option for procedure-name truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-/vendor/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Sample output is here
 |--show-invalids||Show invalid location results|
 |--order|-o|Sort order (default,time,file)|
 |--derived-data-path||Root path of DerivedData directory|
-|--truncate_at|-t|Truncate the method name with specified length|
+|--truncate-at|-t|Truncate the method name with specified length|
 
 ## Use custom reporters
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Sample output is here
 |--show-invalids||Show invalid location results|
 |--order|-o|Sort order (default,time,file)|
 |--derived-data-path||Root path of DerivedData directory|
+|--truncate_at|-t|Truncate the method name with specified length|
 
 ## Use custom reporters
 

--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -25,7 +25,7 @@ module Xcprofiler
         opts.on("-l", "--limit [LIMIT]", Integer, "Limit for display") { |v| options.limit = v }
         opts.on("--threshold [THRESHOLD]", Integer, "Threshold of time to display(ms)") { |v| options.threshold = v }
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
-        opts.on("-t", "--truncate_at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length.") { |v| options.truncate_at = v }
+        opts.on("-t", "--truncate_at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length") { |v| options.truncate_at = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit

--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -25,6 +25,7 @@ module Xcprofiler
         opts.on("-l", "--limit [LIMIT]", Integer, "Limit for display") { |v| options.limit = v }
         opts.on("--threshold [THRESHOLD]", Integer, "Threshold of time to display(ms)") { |v| options.threshold = v }
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
+        opts.on("-t", "--truncate [TRUNCATE_LIMIT]", Integer, "Truncate the method name with specified length.") { |v| options.truncate_limit = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit
@@ -51,7 +52,8 @@ module Xcprofiler
           StandardOutputReporter.new(limit: options[:limit],
                                      threshold: options[:threshold],
                                      order: order,
-                                     show_invalid_locations: options[:show_invalid_locations])
+                                     show_invalid_locations: options[:show_invalid_locations],
+                                     truncate_limit: options[:truncate_limit])
         ]
         profiler.report!
       rescue Exception => e

--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -25,7 +25,7 @@ module Xcprofiler
         opts.on("-l", "--limit [LIMIT]", Integer, "Limit for display") { |v| options.limit = v }
         opts.on("--threshold [THRESHOLD]", Integer, "Threshold of time to display(ms)") { |v| options.threshold = v }
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
-        opts.on("-t", "--truncate_at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length") { |v| options.truncate_at = v }
+        opts.on("-t", "--truncate-at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length") { |v| options.truncate_at = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit

--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -25,7 +25,7 @@ module Xcprofiler
         opts.on("-l", "--limit [LIMIT]", Integer, "Limit for display") { |v| options.limit = v }
         opts.on("--threshold [THRESHOLD]", Integer, "Threshold of time to display(ms)") { |v| options.threshold = v }
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
-        opts.on("-t", "--truncate [TRUNCATE_LIMIT]", Integer, "Truncate the method name with specified length.") { |v| options.truncate_limit = v }
+        opts.on("-t", "--truncate_at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length.") { |v| options.truncate_at = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit
@@ -53,7 +53,7 @@ module Xcprofiler
                                      threshold: options[:threshold],
                                      order: order,
                                      show_invalid_locations: options[:show_invalid_locations],
-                                     truncate_limit: options[:truncate_limit])
+                                     truncate_at: options[:truncate_at])
         ]
         profiler.report!
       rescue Exception => e

--- a/lib/xcprofiler/profiler.rb
+++ b/lib/xcprofiler/profiler.rb
@@ -34,10 +34,10 @@ module Xcprofiler
     private
 
     def reporters
-      @reporters ||= [StandardOutputReporter.new(limit: options[:limit], 
-                                                 threshold: options[:threshold], 
-                                                 order: options[:order], 
-                                                 truncate_limit: options[:truncate_limit])
+      @reporters ||= [StandardOutputReporter.new(limit: options[:limit],
+                                                 threshold: options[:threshold],
+                                                 order: options[:order],
+                                                 truncate_at: options[:truncate_at])
                      ]
     end
   end

--- a/lib/xcprofiler/profiler.rb
+++ b/lib/xcprofiler/profiler.rb
@@ -34,7 +34,11 @@ module Xcprofiler
     private
 
     def reporters
-      @reporters ||= [StandardOutputReporter.new(limit: options[:limit], threshold: options[:threshold], order: options[:order])]
+      @reporters ||= [StandardOutputReporter.new(limit: options[:limit], 
+                                                 threshold: options[:threshold], 
+                                                 order: options[:order], 
+                                                 truncate_limit: options[:truncate_limit])
+                     ]
     end
   end
 end

--- a/lib/xcprofiler/reporters/abstract_reporter.rb
+++ b/lib/xcprofiler/reporters/abstract_reporter.rb
@@ -2,6 +2,8 @@ module Xcprofiler
   class AbstractReporter
     attr_reader :options
 
+    DEFAULT_TRUNCATE_LIMIT = 150
+
     def initialize(options = {})
       @options = options
     end
@@ -45,6 +47,18 @@ module Xcprofiler
 
     def order
       options[:order] || :time
+    end
+
+    def truncate_limit
+      options[:truncate_limit] ||= DEFAULT_TRUNCATE_LIMIT
+    end
+
+    def truncate(text)
+      return text unless text.length >= truncate_limit
+
+      omission = '...'
+      length_with_room_for_omission = truncate_limit - omission.length
+      "#{text[0...length_with_room_for_omission]}#{omission}"
     end
   end
 end

--- a/lib/xcprofiler/reporters/abstract_reporter.rb
+++ b/lib/xcprofiler/reporters/abstract_reporter.rb
@@ -2,7 +2,7 @@ module Xcprofiler
   class AbstractReporter
     attr_reader :options
 
-    DEFAULT_TRUNCATE_LIMIT = 150
+    DEFAULT_TRUNCATE_AT = 150
 
     def initialize(options = {})
       @options = options
@@ -49,16 +49,8 @@ module Xcprofiler
       options[:order] || :time
     end
 
-    def truncate_limit
-      options[:truncate_limit] ||= DEFAULT_TRUNCATE_LIMIT
-    end
-
-    def truncate(text)
-      return text unless text.length >= truncate_limit
-
-      omission = '...'
-      length_with_room_for_omission = truncate_limit - omission.length
-      "#{text[0...length_with_room_for_omission]}#{omission}"
+    def truncate_at
+      options[:truncate_at] ||= DEFAULT_TRUNCATE_AT
     end
   end
 end

--- a/lib/xcprofiler/reporters/standard_output_reporter.rb
+++ b/lib/xcprofiler/reporters/standard_output_reporter.rb
@@ -19,9 +19,9 @@ module Xcprofiler
     end
 
     def truncate(text, truncate_at)
-      return text unless text.length >= truncate_at
-
       omission = '...'
+      return text unless text.length >= truncate_at
+      return text unless truncate_at >= omission.length
       length_with_room_for_omission = truncate_at - omission.length
       "#{text[0...length_with_room_for_omission]}#{omission}"
     end

--- a/lib/xcprofiler/reporters/standard_output_reporter.rb
+++ b/lib/xcprofiler/reporters/standard_output_reporter.rb
@@ -13,7 +13,7 @@ module Xcprofiler
         t << ['File', 'Line', 'Method name', 'Time(ms)']
         t << :separator
         executions.each do |execution|
-          t << [execution.filename, execution.line, execution.method_name, execution.time]
+          t << [execution.filename, execution.line, truncate(execution.method_name), execution.time]
         end
       end
     end

--- a/lib/xcprofiler/reporters/standard_output_reporter.rb
+++ b/lib/xcprofiler/reporters/standard_output_reporter.rb
@@ -17,5 +17,13 @@ module Xcprofiler
         end
       end
     end
+
+    def truncate(text)
+      return text unless text.length >= truncate_at
+
+      omission = '...'
+      length_with_room_for_omission = truncate_at - omission.length
+      "#{text[0...length_with_room_for_omission]}#{omission}"
+    end
   end
 end

--- a/lib/xcprofiler/reporters/standard_output_reporter.rb
+++ b/lib/xcprofiler/reporters/standard_output_reporter.rb
@@ -13,12 +13,12 @@ module Xcprofiler
         t << ['File', 'Line', 'Method name', 'Time(ms)']
         t << :separator
         executions.each do |execution|
-          t << [execution.filename, execution.line, truncate(execution.method_name), execution.time]
+          t << [execution.filename, execution.line, truncate(execution.method_name, truncate_at), execution.time]
         end
       end
     end
 
-    def truncate(text)
+    def truncate(text, truncate_at)
       return text unless text.length >= truncate_at
 
       omission = '...'

--- a/spec/reporters/standard_output_reporter_spec.rb
+++ b/spec/reporters/standard_output_reporter_spec.rb
@@ -19,4 +19,9 @@ describe StandardOutputReporter do
     profiler.report!
     expect(reporter).to have_received(:table_for)
   end
+
+  it 'truncate procedure-name' do
+    expect(reporter.send(:truncate, "xx" * 10, 10)).to eql("x"*7+"...")
+  end
+
 end

--- a/spec/reporters/standard_output_reporter_spec.rb
+++ b/spec/reporters/standard_output_reporter_spec.rb
@@ -23,4 +23,13 @@ describe StandardOutputReporter do
   it 'truncate procedure-name with a valid value' do
     expect(reporter.send(:truncate, "x" * 10, 10)).to eql("x" * 7 + "...")
   end
+
+  it 'truncate method called but the text is too short' do
+    expect(reporter.send(:truncate, "x" * 9, 10)).to eql("x" * 9)
+  end
+
+  it 'trucate method called but truncate_at is too short' do
+    expect(reporter.send(:truncate, "x" * 10 , 2)).to eql("x" * 10)
+  end
 end
+

--- a/spec/reporters/standard_output_reporter_spec.rb
+++ b/spec/reporters/standard_output_reporter_spec.rb
@@ -20,16 +20,19 @@ describe StandardOutputReporter do
     expect(reporter).to have_received(:table_for)
   end
 
-  it 'truncate procedure-name with a valid value' do
-    expect(reporter.send(:truncate, "x" * 10, 10)).to eql("x" * 7 + "...")
-  end
+  describe 'procedure-name truncation' do
+    context 'with a valid value' do
+      it { expect(reporter.send(:truncate, "x" * 10, 10)).to eql("x" * 7 + "...") }
+    end
 
-  it 'truncate method called but the text is too short' do
-    expect(reporter.send(:truncate, "x" * 9, 10)).to eql("x" * 9)
-  end
+    context 'with an invalid value' do
+      it 'the text is too short' do
+        expect(reporter.send(:truncate, "x" * 9, 10)).to eql("x" * 9)
+      end
 
-  it 'trucate method called but truncate_at is too short' do
-    expect(reporter.send(:truncate, "x" * 10 , 2)).to eql("x" * 10)
+      it 'truncate_at is too short' do
+        expect(reporter.send(:truncate, "x" * 10 , 2)).to eql("x" * 10)
+      end
+    end
   end
 end
-

--- a/spec/reporters/standard_output_reporter_spec.rb
+++ b/spec/reporters/standard_output_reporter_spec.rb
@@ -20,19 +20,17 @@ describe StandardOutputReporter do
     expect(reporter).to have_received(:table_for)
   end
 
-  describe 'procedure-name truncation' do
+  describe '#truncate' do
     context 'with a valid value' do
       it { expect(reporter.send(:truncate, "x" * 10, 10)).to eql("x" * 7 + "...") }
     end
 
-    context 'with an invalid value' do
-      it 'the text is too short' do
-        expect(reporter.send(:truncate, "x" * 9, 10)).to eql("x" * 9)
-      end
+    context 'with too short text' do
+      it { expect(reporter.send(:truncate, "x" * 9, 10)).to eql("x" * 9) }
+    end
 
-      it 'truncate_at is too short' do
-        expect(reporter.send(:truncate, "x" * 10 , 2)).to eql("x" * 10)
-      end
+    context 'with too short truncate_at' do
+      it { expect(reporter.send(:truncate, "x" * 10 , 2)).to eql("x" * 10) }
     end
   end
 end

--- a/spec/reporters/standard_output_reporter_spec.rb
+++ b/spec/reporters/standard_output_reporter_spec.rb
@@ -20,8 +20,7 @@ describe StandardOutputReporter do
     expect(reporter).to have_received(:table_for)
   end
 
-  it 'truncate procedure-name' do
-    expect(reporter.send(:truncate, "xx" * 10, 10)).to eql("x"*7+"...")
+  it 'truncate procedure-name with a valid value' do
+    expect(reporter.send(:truncate, "x" * 10, 10)).to eql("x" * 7 + "...")
   end
-
 end


### PR DESCRIPTION
## Overview
Added an option to truncate too long method name.
This pull-request is designed for https://github.com/giginet/xcprofiler/issues/9

## Usage

```
$ xcprofiler biwako-ios -t 30
...
| AppDelegate.swift           | 34   | final get {}                   | 0.02     |
| AppDelegate.swift           | 24   | @objc deinit                   | 0.01     |
| AppDelegate.swift           | 96   | @objc func applicationWillR... | 0.01     |
| AppDelegate.swift           | 116  | @objc func applicationWillT... | 0.01     |
| AppDelegate.swift           | 142  | @objc func gotoSetting()       | 0.01     |
...
```

## Notice
- The default limit is `150`