### PR TITLE
Add output-json option

### DIFF
--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -28,7 +28,7 @@ module Xcprofiler
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
         opts.on("-t", "--truncate-at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length") { |v| options.truncate_at = v }
         opts.on("--[no-]unique", "Reject duplicated location results or not") { |v| options.unique = v }
-        opts.on("--output-path [PATH]", String, "File path to output reporters' result") { |v| options.output_path = v }
+        opts.on("--output [PATH]", String, "File path to output reporters' result") { |v| options.output = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit
@@ -61,9 +61,9 @@ module Xcprofiler
             unique: options[:unique]
         }
         reporters = [StandardOutputReporter.new(reporter_args)]
-        if options[:output_path]
+        if options[:output]
           json_args = options.dup
-          json_args[:output_path] = options[:output_path]
+          json_args[:output] = options[:output]
           reporters << JSONReporter.new(json_args)
         end
 

--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -28,7 +28,7 @@ module Xcprofiler
         opts.on("--derived-data-path", String, "Root path of DerivedData") { |v| options.derived_data_path = v }
         opts.on("-t", "--truncate-at [TRUNCATE_AT]", Integer, "Truncate the method name with specified length") { |v| options.truncate_at = v }
         opts.on("--[no-]unique", "Reject duplicated location results or not") { |v| options.unique = v }
-        opts.on("--output-json [PATH]", String, "File path of output JSON") { |v| options.output_json = v }
+        opts.on("--output-path [PATH]", String, "File path to output reporters' result") { |v| options.output_path = v }
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit
@@ -61,9 +61,9 @@ module Xcprofiler
             unique: options[:unique]
         }
         reporters = [StandardOutputReporter.new(reporter_args)]
-        if options[:output_json]
+        if options[:output_path]
           json_args = options.dup
-          json_args[:output_path] = options[:output_json]
+          json_args[:output_path] = options[:output_path]
           reporters << JSONReporter.new(json_args)
         end
 


### PR DESCRIPTION
closes #20 

Add command line option `--output-path`. You can specify the path indicates output path for `JSONReporter`.

```console
$ xcprofiler --output-path "result.json" MyApp
```