### PR TITLE
Add zero byte filter to xcactivitylog pattern match.

### DIFF
--- a/lib/xcprofiler/derived_data.rb
+++ b/lib/xcprofiler/derived_data.rb
@@ -26,7 +26,7 @@ module Xcprofiler
           raise DerivedDataNotFound, 'Any matching derived data are not found'
         end
 
-        derived_data.max_by { |data| data.updated_at }
+        derived_data.select { |data| !data.zero? }.max_by { |data| data.updated_at }
       end
 
       def default_derived_data_root
@@ -36,6 +36,10 @@ module Xcprofiler
 
     def initialize(path)
       @path = path
+    end
+
+    def zero?
+      File.zero?(@path)
     end
 
     def updated_at


### PR DESCRIPTION
`xcodebuild` sometimes output 0 byte xcactivitylog without `debug-time-function-bodies` flag like this.

```
$ ls -l
total 456
drwxr-xr-x  5 taiki  staff     170 12 14 16:06 ./
drwxr-xr-x  5 taiki  staff     170 12 14 16:03 ../
-rw-r--r--  1 taiki  staff       0 12 14 16:06 2764C2EB-D8CB-4845-9F55-62F0639AD8EF.xcactivitylog
-rw-r--r--  1 taiki  staff  226732 12 14 16:06 2DE13137-4428-4892-8EF6-11634807B4A3.xcactivitylog
-rw-r--r--  1 taiki  staff     541 12 14 16:06 Cache.db
```

This zero byte file created when build Debug configuration with flag and Release configuration without flag at same time. (We are building both configuration at same time in our CI.)

This PR add filtering zero byte xcactivitylog file to find it correctly even if 0 byte file timestamp is newer.

Thanks.