### PR TITLE
Fixed not working --output option

### DIFF
--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -63,7 +63,7 @@ module Xcprofiler
         reporters = [StandardOutputReporter.new(reporter_args)]
         if options[:output]
           json_args = options.dup
-          json_args[:output] = options[:output]
+          json_args[:output_path] = options[:output]
           reporters << JSONReporter.new(json_args)
         end
 


### PR DESCRIPTION
Fixed `--output` option is not working correctly.
`--output` option passed as `output` option, but JSONReporter required `output_path` option.

This is not breaking change to users that using JSONReporter from ruby.
I also make breaking change version of branch https://github.com/r-plus/xcprofiler/commit/d9877238d5c4e12acc235fc07efd94d0ea0cd8e2 that rename to `output` from `output_path` which do you like?

```
$ ./bin/xcprofiler spec/fixtures/MyApp-xxxxxxxxxxx/Logs/Build/valid.xcactivitylog -l 1 -t 10 --output hoge.json
+-------------------+------+-------------+----------+
| File              | Line | Method name | Time(ms) |
+-------------------+------+-------------+----------+
| Interaction.swift | 17   | get {}      | 69.9     |
+-------------------+------+-------------+----------+
[JSONReporter] output_path is not specified
```