### PR TITLE
Switch from colorize to colored2 gem for compatibility with other gems

### DIFF
--- a/lib/xcprofiler.rb
+++ b/lib/xcprofiler.rb
@@ -7,7 +7,7 @@ require "xcprofiler/reporters/abstract_reporter"
 require "xcprofiler/reporters/block_reporter"
 require "xcprofiler/reporters/standard_output_reporter"
 require "xcprofiler/reporters/json_reporter"
-require "colorize"
+require "colored2"
 require "optparse"
 require "ostruct"
 

--- a/lib/xcprofiler/profiler.rb
+++ b/lib/xcprofiler/profiler.rb
@@ -1,5 +1,5 @@
 require 'terminal-table'
-require 'colorize'
+require 'colored2'
 
 module Xcprofiler
   class Profiler

--- a/xcprofiler.gemspec
+++ b/xcprofiler.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls"
 
   spec.add_dependency 'terminal-table'
-  spec.add_dependency 'colorize'
+  spec.add_dependency 'colored2'
 end

--- a/xcprofiler.gemspec
+++ b/xcprofiler.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "coveralls"


### PR DESCRIPTION
I've had trouble using xcprofiler with other gems in the past as everything else in the fastlane/danger universe seems to use `colored` and `colored2`

xcprofiles use of colorize is quite minimal and its an easy change. 